### PR TITLE
Cleanup display

### DIFF
--- a/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
+++ b/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
@@ -39,43 +39,44 @@ public class Parser {
         if (tokens.size() < 1) {
             throw new ParseException("Parse exception (empty string)",0);
         }
-
-        if (tokens.get(0).equalsIgnoreCase("select")) {
-            return parseSelect(partial);
-        }
-
-        if (tokens.get(0).equalsIgnoreCase("colstats")) {
-            return parseColStats(partial);
-        }
-
-        if (tokens.get(0).equalsIgnoreCase("show") && tokens.get(1).equalsIgnoreCase("tables")) {
-            System.out.println(settings.currentDB.showTables());
-            return null;
-        }
-
-        if (tokens.get(0).equalsIgnoreCase("describe")) {
-            table t = settings.currentDB.getTable(tokens.get(1));
-            if (t == null) {
-                throw new ParseException("Parse exception (unknown table " + tokens.get(1) + ")",1);
-            }
-            System.out.println(t.describe());
-            return null;
-        }
         
-        if(tokens.get(0).equalsIgnoreCase("help"))
+        switch(tokens.get(0).toLowerCase())
         {
-            parseHelp(tokens);
-            return null;
-        }
+            case "select":
+                return parseSelect(partial);
+            case "colstats":
+                return parseColStats(partial);
+            case "show":
+                if(tokens.size() == 1 || !tokens.get(1).equalsIgnoreCase("tables"))
+                {
+                    throw new ParseException("Parse Error: Expected 'tables' got"+(tokens.size()==1?"null":tokens.get(1)),1);
+                }
+                System.out.println(settings.currentDB.showTables());
+                break;
+            case "describe":
+                if(tokens.size() == 1 )
+                {
+                    throw new ParseException("Parse Error: Expected table name got nothing",1);
+                }
+                table t = settings.currentDB.getTable(tokens.get(1));
+                if (t == null) {
+                    throw new ParseException("Parse exception (unknown table " + tokens.get(1) + ")",1);
+                }
+                System.out.println(t.describe());
+                break;
+            case "help":
+                parseHelp(tokens);
+                break;
+            case "gc":
+                parseGC(partial);
+                break;
+            default:
+                throw new ParseException("Parse Error: Couldn't parse '"+tokens.getFirst()+"'!",0);
+        } 
         
-        if(tokens.get(0).equalsIgnoreCase("gc"))
-        {
-            return parseGC(partial);
-        }
+        System.err.println("Note: Not running any map/reduce jobs for this query");
 
-        
-        throw new ParseException("Parse Error: Couldn't parse '"+tokens.getFirst()+"'!",0);
-
+        return null;
     }
     
     private static workflow parseGC(LinkedList<String> partial) throws ParseException

--- a/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
+++ b/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
@@ -19,6 +19,7 @@ import com.toddbodnar.simpleHive.subQueries.where;
 import com.toddbodnar.simpleHive.metastore.table;
 import com.toddbodnar.simpleHive.subQueries.colStats;
 import com.toddbodnar.simpleHive.subQueries.join;
+import java.text.ParseException;
 
 /**
  * Builds a Parser tree from a set of tokens
@@ -30,13 +31,13 @@ import com.toddbodnar.simpleHive.subQueries.join;
  */
 public class Parser {
 
-    public static workflow parse(LinkedList<String> tokens) throws Exception {
+    public static workflow parse(LinkedList<String> tokens) throws ParseException {
         LinkedList<String> partial = (LinkedList<String>) tokens.clone();
         if(partial.size() > 0)
             partial.removeFirst();
             
         if (tokens.size() < 1) {
-            throw new Exception("Parse exception (empty string)");
+            throw new ParseException("Parse exception (empty string)",0);
         }
 
         if (tokens.get(0).equalsIgnoreCase("select")) {
@@ -48,15 +49,17 @@ public class Parser {
         }
 
         if (tokens.get(0).equalsIgnoreCase("show") && tokens.get(1).equalsIgnoreCase("tables")) {
-            return new workflow(new printString(settings.currentDB.showTables()));
+            System.out.println(settings.currentDB.showTables());
+            return null;
         }
 
         if (tokens.get(0).equalsIgnoreCase("describe")) {
             table t = settings.currentDB.getTable(tokens.get(1));
             if (t == null) {
-                throw new Exception("Parse exception (unknown table " + tokens.get(1) + ")");
+                throw new ParseException("Parse exception (unknown table " + tokens.get(1) + ")",1);
             }
-            return new workflow(new printString(t.describe()));
+            System.out.println(t.describe());
+            return null;
         }
         
         if(tokens.get(0).equalsIgnoreCase("help"))
@@ -70,11 +73,12 @@ public class Parser {
             return parseGC(partial);
         }
 
-        return null;
+        
+        throw new ParseException("Parse Error: Couldn't parse '"+tokens.getFirst()+"'!",0);
 
     }
     
-    private static workflow parseGC(LinkedList<String> partial) throws Exception
+    private static workflow parseGC(LinkedList<String> partial) throws ParseException
     {
         if(partial.size() == 0)
         {
@@ -85,16 +89,16 @@ public class Parser {
         else if (partial.get(0).equalsIgnoreCase("stats"))
         {
             System.out.println(garbage_collector.stats());
+            
         }
         else
         {
-            throw new Exception("Parse Error: Expected '' or 'stats', got "+partial.get(0));
+            throw new ParseException("Parse Error: Expected '' or 'stats', got "+partial.get(0),1);
         }
-        
-        return null;
+         return null;
     }
 
-    private static workflow parseSelect(LinkedList<String> partial) throws Exception {
+    private static workflow parseSelect(LinkedList<String> partial) throws ParseException {
         workflow select = null;
 
         //a linked list style of joins
@@ -106,17 +110,20 @@ public class Parser {
 
         Iterator<String> itr = partial.iterator();
         String next = itr.next();
-
+        int itrnum = 1;
+        
         String selectArgs = "";
         while (next != null && !next.equalsIgnoreCase("from")) {
             selectArgs += next + " ";
             next = itr.next();
+            itrnum++;
         }
         next = itr.next();
+        itrnum++;
         String fromTableStr = next;
         table fromTable = settings.currentDB.getTable(fromTableStr);
         if (fromTable == null) {
-            throw new Exception("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB));
+            throw new ParseException("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),itrnum);
         }
 
         select = new workflow(new select(selectArgs));
@@ -124,32 +131,38 @@ public class Parser {
         select.job.setInput(fromTable);
         if (itr.hasNext()) {
             next = itr.next();
+            itrnum++;
             while (next.equalsIgnoreCase("JOIN")) {
                 fromTableStr = itr.next();
+                itrnum++;
                 table joinTable = settings.currentDB.getTable(fromTableStr);
                 if (joinTable == null) {
-                    throw new Exception("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB));
+                    throw new ParseException("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),itrnum);
                 }
 
                 next = itr.next();
+                itrnum++;
                 if (!next.equalsIgnoreCase("ON")) {
-                    throw new Exception("SQL Error: Expected keyword 'ON', found " + next);
+                    throw new ParseException("SQL Error: Expected keyword 'ON', found " + next,itrnum);
                 }
                 String t1JoinCol = itr.next();
+                itrnum++;
                 next = itr.next();
                 String t2JoinCol = itr.next();
+                itrnum++;
                 if (!next.equals("=")) {
-                    throw new Exception("SQL Error: Expected '=' in join statement, got " + next);
+                    itrnum++;
+                    throw new ParseException("SQL Error: Expected '=' in join statement, got " + next,itrnum);
                 }
 
                 int t1JoinColNum = fromTable.getColNum(t1JoinCol);
                 int t2JoinColNum = joinTable.getColNum(t2JoinCol);
 
                 if (t1JoinColNum == -1) {
-                    throw new Exception("SQL Error: Could not find column '" + t1JoinCol + "' in table " + fromTable);
+                    throw new ParseException("SQL Error: Could not find column '" + t1JoinCol + "' in table " + fromTable,itrnum-2);
                 }
                 if (t2JoinColNum == -1) {
-                    throw new Exception("SQL Error: Could not find column '" + t2JoinCol + "' in table " + joinTable);
+                    throw new ParseException("SQL Error: Could not find column '" + t2JoinCol + "' in table " + joinTable,itrnum);
                 }
 
                 join join = new join(t1JoinColNum, t2JoinColNum);
@@ -161,6 +174,7 @@ public class Parser {
                 select = joinwf;
 
                 if (itr.hasNext()) {
+                    itrnum++;
                     next = itr.next();
                 } else {
                     next = "null";
@@ -169,12 +183,13 @@ public class Parser {
             if (itr.hasNext()) {
                 //next = itr.next();
                 if (!next.equalsIgnoreCase("WHERE")) {
-                    throw new Exception("Expected where clause, found " + next);
+                    throw new ParseException("Expected where clause, found " + next,itrnum);
                 }
 
                 String remaining = "";
                 while (itr.hasNext()) {
                     remaining += itr.next() + " ";
+                    itrnum++;
                 }
                 where = new workflow(new where(remaining));
                 where.job.setInput(fromTable);
@@ -193,7 +208,7 @@ public class Parser {
      * @param tokens
      * @return
      */
-    private static workflow parseColStats(LinkedList<String> tokens) throws Exception {
+    private static workflow parseColStats(LinkedList<String> tokens) throws ParseException {
         int tokenCount = 1;
         int columnId, groupId = -1;
         String column_name = tokens.get(0);
@@ -201,33 +216,33 @@ public class Parser {
         String group_name = null;
         if (tokens.get(1).equalsIgnoreCase("GROUP")) {
             if (!tokens.get(2).equalsIgnoreCase("BY")) {
-                throw new Exception("SQL Error: Expected keyword 'on' found " + tokens.get(2));
+                throw new ParseException("SQL Error: Expected keyword 'on' found " + tokens.get(2),2);
             }
             group_name = tokens.get(3);
             tokenCount = 4;
         }
         if (!tokens.get(tokenCount).equalsIgnoreCase("FROM")) {
-            throw new Exception("SQL Error: Expected keyword 'from' found " + tokens.get(tokenCount));
+            throw new ParseException("SQL Error: Expected keyword 'from' found " + tokens.get(tokenCount),tokenCount);
         }
         tokenCount++;
         if (tokens.get(tokenCount).equalsIgnoreCase("SELECT")) {
-            throw new Exception("Not Yet Implemented: Doing col stats on a generated table (using SELECT)");
+            throw new ParseException("Not Yet Implemented: Doing col stats on a generated table (using SELECT)",tokenCount);
         }
 
         table input = settings.currentDB.getTable(tokens.get(tokenCount));
         if (input == null) {
-            throw new Exception("SQL Error: cannot find table: " + ((tokens.get(tokenCount) == null) ? "null" : tokens.get(tokenCount)) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB));
+            throw new ParseException("SQL Error: cannot find table: " + ((tokens.get(tokenCount) == null) ? "null" : tokens.get(tokenCount)) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),tokenCount);
         }
 
         columnId = input.getColNum(column_name);
         if (columnId == -1) {
-            throw new Exception("SQL Error: cannot find column " + column_name);
+            throw new ParseException("SQL Error: cannot find column " + column_name,tokenCount);
         }
 
         if (group_name != null) {
             groupId = input.getColNum(group_name);
             if (groupId == -1) {
-                throw new Exception("SQL Error: cannot find column " + group_name);
+                throw new ParseException("SQL Error: cannot find column " + group_name,tokenCount);
             }
         }
 

--- a/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
+++ b/SimpleHive/src/main/java/com/toddbodnar/simpleHive/compiler/Parser.java
@@ -37,7 +37,7 @@ public class Parser {
             partial.removeFirst();
             
         if (tokens.size() < 1) {
-            throw new ParseException("Parse exception (empty string)",0);
+            throw new ParseException("Parse Error: Empty string",0);
         }
         
         switch(tokens.get(0).toLowerCase())
@@ -60,7 +60,7 @@ public class Parser {
                 }
                 table t = settings.currentDB.getTable(tokens.get(1));
                 if (t == null) {
-                    throw new ParseException("Parse exception (unknown table " + tokens.get(1) + ")",1);
+                    throw new ParseException("Parse Error: Unknown table '" + tokens.get(1) + "'",1);
                 }
                 System.out.println(t.describe());
                 break;
@@ -124,7 +124,7 @@ public class Parser {
         String fromTableStr = next;
         table fromTable = settings.currentDB.getTable(fromTableStr);
         if (fromTable == null) {
-            throw new ParseException("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),itrnum);
+            throw new ParseException("Parse Error: Cannot find table '" + ((fromTableStr == null) ? "null" : fromTableStr) + "' in database '" + ((settings.currentDB == null) ? "null" : settings.currentDB)+"'",itrnum);
         }
 
         select = new workflow(new select(selectArgs));
@@ -138,13 +138,13 @@ public class Parser {
                 itrnum++;
                 table joinTable = settings.currentDB.getTable(fromTableStr);
                 if (joinTable == null) {
-                    throw new ParseException("SQL Error: cannot find table: " + ((fromTableStr == null) ? "null" : fromTableStr) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),itrnum);
+                    throw new ParseException("Parse Error: Cannot find table '" + ((fromTableStr == null) ? "null" : fromTableStr) + "' in database '" + ((settings.currentDB == null) ? "null" : settings.currentDB)+"'",itrnum);
                 }
 
                 next = itr.next();
                 itrnum++;
                 if (!next.equalsIgnoreCase("ON")) {
-                    throw new ParseException("SQL Error: Expected keyword 'ON', found " + next,itrnum);
+                    throw new ParseException("Parse Error: Expected keyword 'ON', found " + next,itrnum);
                 }
                 String t1JoinCol = itr.next();
                 itrnum++;
@@ -153,17 +153,17 @@ public class Parser {
                 itrnum++;
                 if (!next.equals("=")) {
                     itrnum++;
-                    throw new ParseException("SQL Error: Expected '=' in join statement, got " + next,itrnum);
+                    throw new ParseException("Parse Error: Expected '=' in join statement, got '" + next+"'",itrnum);
                 }
 
                 int t1JoinColNum = fromTable.getColNum(t1JoinCol);
                 int t2JoinColNum = joinTable.getColNum(t2JoinCol);
 
                 if (t1JoinColNum == -1) {
-                    throw new ParseException("SQL Error: Could not find column '" + t1JoinCol + "' in table " + fromTable,itrnum-2);
+                    throw new ParseException("Parse Error: Could not find column '" + t1JoinCol + "' in table '" + fromTable+"'",itrnum-2);
                 }
                 if (t2JoinColNum == -1) {
-                    throw new ParseException("SQL Error: Could not find column '" + t2JoinCol + "' in table " + joinTable,itrnum);
+                    throw new ParseException("Parse Error: Could not find column '" + t2JoinCol + "' in table '" + joinTable+"'",itrnum);
                 }
 
                 join join = new join(t1JoinColNum, t2JoinColNum);
@@ -184,7 +184,7 @@ public class Parser {
             if (itr.hasNext()) {
                 //next = itr.next();
                 if (!next.equalsIgnoreCase("WHERE")) {
-                    throw new ParseException("Expected where clause, found " + next,itrnum);
+                    throw new ParseException("Parse Error: Expected where clause, found '" + next+"'",itrnum);
                 }
 
                 String remaining = "";
@@ -217,13 +217,13 @@ public class Parser {
         String group_name = null;
         if (tokens.get(1).equalsIgnoreCase("GROUP")) {
             if (!tokens.get(2).equalsIgnoreCase("BY")) {
-                throw new ParseException("SQL Error: Expected keyword 'on' found " + tokens.get(2),2);
+                throw new ParseException("Parse Error: Expected keyword 'on' found '" + tokens.get(2)+"'",2);
             }
             group_name = tokens.get(3);
             tokenCount = 4;
         }
         if (!tokens.get(tokenCount).equalsIgnoreCase("FROM")) {
-            throw new ParseException("SQL Error: Expected keyword 'from' found " + tokens.get(tokenCount),tokenCount);
+            throw new ParseException("Parse Error: Expected keyword 'from' found '" + tokens.get(tokenCount)+"'",tokenCount);
         }
         tokenCount++;
         if (tokens.get(tokenCount).equalsIgnoreCase("SELECT")) {
@@ -232,18 +232,18 @@ public class Parser {
 
         table input = settings.currentDB.getTable(tokens.get(tokenCount));
         if (input == null) {
-            throw new ParseException("SQL Error: cannot find table: " + ((tokens.get(tokenCount) == null) ? "null" : tokens.get(tokenCount)) + " in database " + ((settings.currentDB == null) ? "null" : settings.currentDB),tokenCount);
+            throw new ParseException("Parse Error: cannot find table '" + ((tokens.get(tokenCount) == null) ? "null" : tokens.get(tokenCount)) + "' in database '" + ((settings.currentDB == null) ? "null" : settings.currentDB)+"'",tokenCount);
         }
 
         columnId = input.getColNum(column_name);
         if (columnId == -1) {
-            throw new ParseException("SQL Error: cannot find column " + column_name,tokenCount);
+            throw new ParseException("Parse Error: cannot find column '" + column_name+"'",tokenCount);
         }
 
         if (group_name != null) {
             groupId = input.getColNum(group_name);
             if (groupId == -1) {
-                throw new ParseException("SQL Error: cannot find column " + group_name,tokenCount);
+                throw new ParseException("Parse Error: cannot find column '" + group_name+"''",tokenCount);
             }
         }
 

--- a/SimpleHive/src/main/java/com/toddbodnar/simpleHive/subQueries/join.java
+++ b/SimpleHive/src/main/java/com/toddbodnar/simpleHive/subQueries/join.java
@@ -43,6 +43,11 @@ public class join extends query<Text, Text> {
     public table getOtherInput() {
         return other;
     }
+    
+    public String toString()
+    {
+        return "Join query : Join tables "+(getInput()==null?"null":getInput().toString())+" and "+(other==null?"null":other.toString())+" on columns "+(getInput()==null?mainKey:getInput().getColName(mainKey))+" and "+(other==null?otherKey:other.getColName(otherKey));
+    }
 
     table other;
     ramFile storage;


### PR DESCRIPTION
- Error output is standardized.
- Less "hard errors" when doing unusual things (i.e. print out a friendly error message instead of a stack trace)
- join.toString() is now human readible
